### PR TITLE
Fix grand total calculation on add purchases

### DIFF
--- a/app/warehouse/[id]/admin/purchases/add/page.tsx
+++ b/app/warehouse/[id]/admin/purchases/add/page.tsx
@@ -147,7 +147,8 @@ export default function AddPurchasePage() {
       const existingItem = updatedItems[existingItemIndex]
       existingItem.quantity += quantity
       existingItem.discount += discount
-      existingItem.total = existingItem.selectedPrice * existingItem.quantity - existingItem.discount
+      const unitCost = existingItem.customCost !== undefined ? existingItem.customCost : existingItem.cost
+      existingItem.total = unitCost * existingItem.quantity - existingItem.discount
       setPurchaseItems(updatedItems)
     }else{
       const effectiveRetailPrice = enableCustomPrices && customRetailPrice !== undefined ? customRetailPrice : selectedProduct.retailPrice
@@ -155,7 +156,8 @@ export default function AddPurchasePage() {
       
       const selectedPrice = priceType === "wholesale" ? effectiveWholesalePrice : effectiveRetailPrice
   
-      const itemTotal = customCost ? customCost : selectedProduct.cost * quantity - discount
+      const unitCost = enableCustomPrices && customCost !== undefined ? customCost : selectedProduct.cost
+      const itemTotal = unitCost * quantity - discount
       const newItem: PurchaseItem = {
         id: `ITEM-${Date.now()}`,
           productId: selectedProduct.id,


### PR DESCRIPTION
Correct purchase item total calculation to consistently use unit cost, resolving grand total inaccuracies after price updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa77cd2c-bd5c-4668-bf05-3915c55ab8bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa77cd2c-bd5c-4668-bf05-3915c55ab8bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

